### PR TITLE
update issues link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This repository exists as a central place to share resources and instructions. T
 
 ## Contributing
 
-We welcome new contributors. Not sure where to start? Check for any [open issues ](https://github.com/CodeForFoco/bike-coop/issues) or ping the team on [our slack channel](https://codeforfoco.slack.com/).
+We welcome new contributors. Not sure where to start? Check for any [open issues ][trello] or ping the team on [our slack channel](https://codeforfoco.slack.com/).  The [GitHub issue tracker][githubissue] is not currently used.
 
 Ensure your code follows best practices and adheres to good style.
 
@@ -52,3 +52,6 @@ If you are unfamiliar with git, check the resources below or ping us on Slack an
 
 - [Fork A Repo](https://help.github.com/articles/fork-a-repo/)
 - [Github Workflow](https://guides.github.com/introduction/flow/)
+
+[trello]: https://trello.com/b/Zrj0doO2/fort-collins-bike-co-op
+[githubissue]: https://github.com/CodeForFoco/bike-coop/issues


### PR DESCRIPTION
- Update the issues link to point to the Trello board.
- Use footnote-style links for issue links.
- Refer to deprecated GitHub issues for posterity.
